### PR TITLE
fixed "dotnet publish" line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /source/src
 # If TARGETARCH is "amd64", replace it with "x64" - "x64" is .NET's canonical name for this and "amd64" doesn't
 #   work in .NET 6.0.
 RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
-    dotnet publish -a ${TARGETARCH/amd64/x64} --use-current-runtime --self-contained false -o /app
+    dotnet publish src.sln -a ${TARGETARCH/amd64/x64} --use-current-runtime --self-contained false -o /app
 
 # If you need to enable globalization and time zones:
 # https://github.com/dotnet/dotnet-docker/blob/main/samples/enable-globalization.md


### PR DESCRIPTION
While studying Docker Language-specific guides I came across a problem:

`=> ERROR [server build 4/5] RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages     dotnet publish -a ${TARGETARCH/amd64/x64} --use-current-runtime --self-contained false -o /app                                  0.5s 
------
 > [server build 4/5] RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages     dotnet publish -a ${TARGETARCH/amd64/x64} --use-current-runtime --self-contained false -o /app:
0.455 MSBuild version 17.3.2+561848881 for .NET
0.456 MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.
------
failed to solve: process "/bin/sh -c dotnet publish -a ${TARGETARCH/amd64/x64} --use-current-runtime --self-contained false -o /app" did not complete successfully: exit code: 1`

This problem was fixed by me and updated in my fork